### PR TITLE
feat(phase3): SARIF/GHA output formatters and complete all 41 lint rules

### DIFF
--- a/crates/rigsql-cli/src/main.rs
+++ b/crates/rigsql-cli/src/main.rs
@@ -103,6 +103,8 @@ enum ParseFormat {
 enum LintFormat {
     Human,
     Json,
+    Sarif,
+    Github,
 }
 
 fn main() {
@@ -321,7 +323,7 @@ fn cmd_lint(files: &[String], dialect: DialectKind, format: LintFormat, no_color
                     print!("{output}");
                 }
             }
-            LintFormat::Json => {
+            LintFormat::Json | LintFormat::Sarif | LintFormat::Github => {
                 json_results.push((path.clone(), source, violations));
             }
         }
@@ -333,15 +335,29 @@ fn cmd_lint(files: &[String], dialect: DialectKind, format: LintFormat, no_color
                 formatter.format_summary(sql_files.len(), files_with_violations, total_violations);
             print!("{summary}");
         }
-        LintFormat::Json => {
+        LintFormat::Json | LintFormat::Sarif | LintFormat::Github => {
             let refs: Vec<(&Path, &str, &[rigsql_rules::LintViolation])> = json_results
                 .iter()
                 .map(|(p, s, v)| (p.as_path(), s.as_str(), v.as_slice()))
                 .collect();
-            println!(
-                "{}",
-                rigsql_output::JsonFormatter::format_with_rules(&refs, &rules)
-            );
+            match format {
+                LintFormat::Json => {
+                    println!(
+                        "{}",
+                        rigsql_output::JsonFormatter::format_with_rules(&refs, &rules)
+                    );
+                }
+                LintFormat::Sarif => {
+                    println!(
+                        "{}",
+                        rigsql_output::SarifFormatter::format_with_rules(&refs, &rules)
+                    );
+                }
+                LintFormat::Github => {
+                    print!("{}", rigsql_output::GithubFormatter::format(&refs));
+                }
+                LintFormat::Human => unreachable!(),
+            }
         }
     }
 

--- a/crates/rigsql-output/src/github.rs
+++ b/crates/rigsql-output/src/github.rs
@@ -1,0 +1,33 @@
+use std::path::Path;
+
+use rigsql_rules::LintViolation;
+
+/// GitHub Actions workflow command formatter.
+///
+/// Outputs violations as `::warning` commands that GitHub Actions
+/// interprets as file annotations visible in pull request diffs.
+///
+/// Format: `::warning file={path},line={line},col={col}::{message}`
+pub struct GithubFormatter;
+
+impl GithubFormatter {
+    pub fn format(file_results: &[(&Path, &str, &[LintViolation])]) -> String {
+        let mut out = String::new();
+
+        for (path, source, violations) in file_results {
+            for v in *violations {
+                let (line, col) = v.line_col(source);
+                out.push_str(&format!(
+                    "::warning file={},line={},col={}::{} {}\n",
+                    path.display(),
+                    line,
+                    col,
+                    v.rule_code,
+                    v.message,
+                ));
+            }
+        }
+
+        out
+    }
+}

--- a/crates/rigsql-output/src/lib.rs
+++ b/crates/rigsql-output/src/lib.rs
@@ -1,5 +1,9 @@
+mod github;
 mod human;
 mod json;
+mod sarif;
 
+pub use github::GithubFormatter;
 pub use human::HumanFormatter;
 pub use json::JsonFormatter;
+pub use sarif::SarifFormatter;

--- a/crates/rigsql-output/src/sarif.rs
+++ b/crates/rigsql-output/src/sarif.rs
@@ -1,0 +1,178 @@
+use std::path::Path;
+
+use rigsql_rules::{LintViolation, Rule};
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// SARIF v2.1.0 output formatter.
+///
+/// Produces Static Analysis Results Interchange Format (SARIF) JSON,
+/// compatible with GitHub Code Scanning, VS Code SARIF Viewer, and
+/// other SARIF-consuming tools.
+pub struct SarifFormatter;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifLog {
+    #[serde(rename = "$schema")]
+    schema: &'static str,
+    version: &'static str,
+    runs: Vec<SarifRun>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifRun {
+    tool: SarifTool,
+    results: Vec<SarifResult>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifTool {
+    driver: SarifDriver,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifDriver {
+    name: &'static str,
+    version: &'static str,
+    information_uri: &'static str,
+    rules: Vec<SarifRuleDescriptor>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifRuleDescriptor {
+    id: String,
+    name: String,
+    short_description: SarifMessage,
+    full_description: SarifMessage,
+    default_configuration: SarifRuleConfig,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifRuleConfig {
+    level: &'static str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifResult {
+    rule_id: String,
+    rule_index: usize,
+    level: &'static str,
+    message: SarifMessage,
+    locations: Vec<SarifLocation>,
+}
+
+#[derive(Serialize)]
+struct SarifMessage {
+    text: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifLocation {
+    physical_location: SarifPhysicalLocation,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifPhysicalLocation {
+    artifact_location: SarifArtifactLocation,
+    region: SarifRegion,
+}
+
+#[derive(Serialize)]
+struct SarifArtifactLocation {
+    uri: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifRegion {
+    start_line: usize,
+    start_column: usize,
+}
+
+impl SarifFormatter {
+    pub fn format_with_rules(
+        file_results: &[(&Path, &str, &[LintViolation])],
+        rules: &[Box<dyn Rule>],
+    ) -> String {
+        // Build rule descriptors and index map
+        let mut rule_indices: HashMap<&str, usize> = HashMap::new();
+        let rule_descriptors: Vec<SarifRuleDescriptor> = rules
+            .iter()
+            .enumerate()
+            .map(|(i, r)| {
+                rule_indices.insert(r.code(), i);
+                SarifRuleDescriptor {
+                    id: r.code().to_string(),
+                    name: r.name().to_string(),
+                    short_description: SarifMessage {
+                        text: r.description().to_string(),
+                    },
+                    full_description: SarifMessage {
+                        text: r.explanation().to_string(),
+                    },
+                    default_configuration: SarifRuleConfig { level: "warning" },
+                }
+            })
+            .collect();
+
+        // Build results
+        let results: Vec<SarifResult> = file_results
+            .iter()
+            .flat_map(|(path, source, violations)| {
+                let indices = &rule_indices;
+                violations.iter().map(move |v| {
+                    let (line, col) = v.line_col(source);
+                    let rule_index = indices.get(v.rule_code).copied().unwrap_or(0);
+
+                    SarifResult {
+                        rule_id: v.rule_code.to_string(),
+                        rule_index,
+                        level: "warning",
+                        message: SarifMessage {
+                            text: v.message.clone(),
+                        },
+                        locations: vec![SarifLocation {
+                            physical_location: SarifPhysicalLocation {
+                                artifact_location: SarifArtifactLocation {
+                                    uri: path.display().to_string(),
+                                },
+                                region: SarifRegion {
+                                    start_line: line,
+                                    start_column: col,
+                                },
+                            },
+                        }],
+                    }
+                })
+            })
+            .collect();
+
+        let log = SarifLog {
+            schema:
+                "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+            version: "2.1.0",
+            runs: vec![SarifRun {
+                tool: SarifTool {
+                    driver: SarifDriver {
+                        name: "rigsql",
+                        version: env!("CARGO_PKG_VERSION"),
+                        information_uri: "https://github.com/yukonsky/rigsql",
+                        rules: rule_descriptors,
+                    },
+                },
+                results,
+            }],
+        };
+
+        serde_json::to_string_pretty(&log).unwrap()
+    }
+}

--- a/crates/rigsql-rules/src/aliasing/al04.rs
+++ b/crates/rigsql-rules/src/aliasing/al04.rs
@@ -1,6 +1,9 @@
+use std::collections::HashMap;
+
 use rigsql_core::{Segment, SegmentType};
 
 use crate::rule::{CrawlType, Rule, RuleContext, RuleGroup};
+use crate::utils::extract_alias_name;
 use crate::violation::LintViolation;
 
 /// AL04: Table aliases should be unique within a statement.
@@ -40,11 +43,11 @@ impl Rule for RuleAL04 {
         collect_table_aliases(ctx.segment, &mut aliases);
 
         let mut violations = Vec::new();
-        let mut seen: Vec<(String, rigsql_core::Span)> = Vec::new();
+        let mut seen: HashMap<String, rigsql_core::Span> = HashMap::new();
 
         for (name, span) in &aliases {
             let lower = name.to_lowercase();
-            if let Some((_, first_span)) = seen.iter().find(|(n, _)| *n == lower) {
+            if let Some(first_span) = seen.get(&lower) {
                 violations.push(LintViolation::new(
                     self.code(),
                     format!(
@@ -54,7 +57,7 @@ impl Rule for RuleAL04 {
                     *span,
                 ));
             } else {
-                seen.push((lower, *span));
+                seen.insert(lower, *span);
             }
         }
 
@@ -89,7 +92,7 @@ fn collect_table_aliases(segment: &Segment, aliases: &mut Vec<(String, rigsql_co
 /// Find AliasExpression nodes and extract the alias name (last identifier).
 fn find_alias_names(segment: &Segment, aliases: &mut Vec<(String, rigsql_core::Span)>) {
     if segment.segment_type() == SegmentType::AliasExpression {
-        if let Some(name) = extract_alias_name(segment) {
+        if let Some(name) = extract_alias_name(segment.children()) {
             aliases.push((name, segment.span()));
         }
         return;
@@ -103,28 +106,4 @@ fn find_alias_names(segment: &Segment, aliases: &mut Vec<(String, rigsql_core::S
     for child in segment.children() {
         find_alias_names(child, aliases);
     }
-}
-
-/// Extract the alias name from an AliasExpression.
-/// The alias name is typically the last Identifier after AS keyword.
-fn extract_alias_name(alias_expr: &Segment) -> Option<String> {
-    let children = alias_expr.children();
-    // Walk children in reverse to find the last identifier (the alias name)
-    for child in children.iter().rev() {
-        let st = child.segment_type();
-        if st == SegmentType::Identifier || st == SegmentType::QuotedIdentifier {
-            if let Segment::Token(t) = child {
-                return Some(t.token.text.to_string());
-            }
-        }
-        // Skip trivia
-        if st.is_trivia() {
-            continue;
-        }
-        // If we hit something that's not trivia or identifier, stop
-        if st != SegmentType::Keyword {
-            break;
-        }
-    }
-    None
 }

--- a/crates/rigsql-rules/src/aliasing/al06.rs
+++ b/crates/rigsql-rules/src/aliasing/al06.rs
@@ -1,0 +1,74 @@
+use rigsql_core::{Segment, SegmentType};
+
+use crate::rule::{CrawlType, Rule, RuleContext, RuleGroup};
+use crate::violation::LintViolation;
+
+/// AL06: Subqueries in FROM clause should have an alias.
+///
+/// A subquery used as a table source must be given an explicit alias
+/// so that its columns can be referenced unambiguously.
+#[derive(Debug, Default)]
+pub struct RuleAL06;
+
+impl Rule for RuleAL06 {
+    fn code(&self) -> &'static str {
+        "AL06"
+    }
+    fn name(&self) -> &'static str {
+        "aliasing.subquery"
+    }
+    fn description(&self) -> &'static str {
+        "Subqueries in FROM clause should have an alias."
+    }
+    fn explanation(&self) -> &'static str {
+        "When a subquery is used as a table source in a FROM or JOIN clause, \
+         it must be given an explicit alias. Without an alias, columns from the \
+         subquery cannot be referenced clearly in the outer query."
+    }
+    fn groups(&self) -> &[RuleGroup] {
+        &[RuleGroup::Aliasing]
+    }
+    fn is_fixable(&self) -> bool {
+        false
+    }
+
+    fn crawl_type(&self) -> CrawlType {
+        CrawlType::Segment(vec![SegmentType::FromClause, SegmentType::JoinClause])
+    }
+
+    fn eval(&self, ctx: &RuleContext) -> Vec<LintViolation> {
+        let mut violations = Vec::new();
+        check_subqueries_have_alias(ctx.segment, &mut violations, self.code());
+        violations
+    }
+}
+
+fn check_subqueries_have_alias(
+    segment: &Segment,
+    violations: &mut Vec<LintViolation>,
+    code: &'static str,
+) {
+    let children = segment.children();
+
+    for child in children {
+        let st = child.segment_type();
+
+        // A bare Subquery (not wrapped in AliasExpression) lacks an alias
+        if st == SegmentType::Subquery {
+            violations.push(LintViolation::new(
+                code,
+                "Subquery in FROM/JOIN clause should have an alias.",
+                child.span(),
+            ));
+            continue;
+        }
+
+        // AliasExpression wraps aliased subqueries — skip (already aliased)
+        if st == SegmentType::AliasExpression {
+            continue;
+        }
+
+        // Recurse into other nodes (e.g., JoinClause inside FromClause)
+        check_subqueries_have_alias(child, violations, code);
+    }
+}

--- a/crates/rigsql-rules/src/aliasing/al08.rs
+++ b/crates/rigsql-rules/src/aliasing/al08.rs
@@ -1,0 +1,68 @@
+use std::collections::HashMap;
+
+use rigsql_core::SegmentType;
+
+use crate::rule::{CrawlType, Rule, RuleContext, RuleGroup};
+use crate::utils::extract_alias_name;
+use crate::violation::LintViolation;
+
+/// AL08: Column aliases should be unique within each SELECT clause.
+///
+/// Duplicate column aliases create ambiguity in the result set.
+#[derive(Debug, Default)]
+pub struct RuleAL08;
+
+impl Rule for RuleAL08 {
+    fn code(&self) -> &'static str {
+        "AL08"
+    }
+    fn name(&self) -> &'static str {
+        "aliasing.unique_column"
+    }
+    fn description(&self) -> &'static str {
+        "Column aliases should be unique within each statement."
+    }
+    fn explanation(&self) -> &'static str {
+        "When the same alias is used for multiple columns in a single SELECT clause, \
+         the result set becomes ambiguous. Each column alias must be unique within \
+         its containing SELECT clause."
+    }
+    fn groups(&self) -> &[RuleGroup] {
+        &[RuleGroup::Aliasing]
+    }
+    fn is_fixable(&self) -> bool {
+        false
+    }
+
+    fn crawl_type(&self) -> CrawlType {
+        CrawlType::Segment(vec![SegmentType::SelectClause])
+    }
+
+    fn eval(&self, ctx: &RuleContext) -> Vec<LintViolation> {
+        let mut violations = Vec::new();
+        let mut seen: HashMap<String, rigsql_core::Span> = HashMap::new();
+
+        for child in ctx.segment.children() {
+            if child.segment_type() == SegmentType::AliasExpression {
+                if let Some(name) = extract_alias_name(child.children()) {
+                    let span = child.span();
+                    let lower = name.to_lowercase();
+                    if let Some(first_span) = seen.get(&lower) {
+                        violations.push(LintViolation::new(
+                            self.code(),
+                            format!(
+                                "Duplicate column alias '{}'. First used at offset {}.",
+                                name, first_span.start,
+                            ),
+                            span,
+                        ));
+                    } else {
+                        seen.insert(lower, span);
+                    }
+                }
+            }
+        }
+
+        violations
+    }
+}

--- a/crates/rigsql-rules/src/aliasing/al09.rs
+++ b/crates/rigsql-rules/src/aliasing/al09.rs
@@ -1,0 +1,144 @@
+use rigsql_core::{Segment, SegmentType, Span};
+
+use crate::rule::{CrawlType, Rule, RuleContext, RuleGroup};
+use crate::violation::{LintViolation, SourceEdit};
+
+/// AL09: Self-aliasing of columns.
+///
+/// Aliasing a column to itself (e.g., `col AS col`) is redundant and
+/// should be removed to improve readability.
+#[derive(Debug, Default)]
+pub struct RuleAL09;
+
+impl Rule for RuleAL09 {
+    fn code(&self) -> &'static str {
+        "AL09"
+    }
+    fn name(&self) -> &'static str {
+        "aliasing.self_alias"
+    }
+    fn description(&self) -> &'static str {
+        "Self-aliasing of columns is redundant."
+    }
+    fn explanation(&self) -> &'static str {
+        "Writing `col AS col` or `table.col AS col` aliases a column to its own name. \
+         This is redundant and adds unnecessary noise. Remove the AS clause to simplify \
+         the query."
+    }
+    fn groups(&self) -> &[RuleGroup] {
+        &[RuleGroup::Aliasing]
+    }
+    fn is_fixable(&self) -> bool {
+        true
+    }
+
+    fn crawl_type(&self) -> CrawlType {
+        CrawlType::Segment(vec![SegmentType::AliasExpression])
+    }
+
+    fn eval(&self, ctx: &RuleContext) -> Vec<LintViolation> {
+        // Only check column aliases (within SelectClause)
+        let in_select = ctx
+            .parent
+            .is_some_and(|p| p.segment_type() == SegmentType::SelectClause);
+        if !in_select {
+            return vec![];
+        }
+
+        let children = ctx.segment.children();
+
+        // Single-pass extraction: source name, alias name, and AS-to-end span
+        let Some(info) = extract_self_alias_info(children) else {
+            return vec![];
+        };
+
+        if !info.alias_name.eq_ignore_ascii_case(&info.source_name) {
+            return vec![];
+        }
+
+        vec![LintViolation::with_fix(
+            self.code(),
+            format!("Column '{}' is aliased to itself.", info.source_name),
+            ctx.segment.span(),
+            vec![SourceEdit::delete(info.remove_span)],
+        )]
+    }
+}
+
+struct SelfAliasInfo {
+    source_name: String,
+    alias_name: String,
+    remove_span: Span,
+}
+
+/// Single-pass extraction of source name, alias name, and the span to remove.
+fn extract_self_alias_info(children: &[Segment]) -> Option<SelfAliasInfo> {
+    let mut source_name: Option<String> = None;
+    let mut alias_name: Option<String> = None;
+    let mut as_region_start: Option<u32> = None;
+    let mut found_as = false;
+    let mut prev_trivia_start: Option<u32> = None;
+
+    for child in children {
+        let st = child.segment_type();
+
+        if !found_as {
+            // Before AS: track source column name
+            if st == SegmentType::Keyword {
+                if let Segment::Token(t) = child {
+                    if t.token.text.as_str().eq_ignore_ascii_case("AS") {
+                        found_as = true;
+                        // Include preceding whitespace in removal span
+                        as_region_start = Some(prev_trivia_start.unwrap_or(child.span().start));
+                        continue;
+                    }
+                }
+            }
+            if st.is_trivia() {
+                if prev_trivia_start.is_none() || source_name.is_some() {
+                    prev_trivia_start = Some(child.span().start);
+                }
+            } else {
+                prev_trivia_start = None;
+                // Extract source identifier
+                if st == SegmentType::ColumnRef || st == SegmentType::QualifiedIdentifier {
+                    source_name = find_last_identifier_in(child);
+                } else if st == SegmentType::Identifier || st == SegmentType::QuotedIdentifier {
+                    if let Segment::Token(t) = child {
+                        source_name = Some(t.token.text.to_string());
+                    }
+                }
+            }
+        } else {
+            // After AS: find alias identifier
+            if (st == SegmentType::Identifier || st == SegmentType::QuotedIdentifier)
+                && alias_name.is_none()
+            {
+                if let Segment::Token(t) = child {
+                    alias_name = Some(t.token.text.to_string());
+                }
+            }
+        }
+    }
+
+    let end = children.last()?.span().end;
+    Some(SelfAliasInfo {
+        source_name: source_name?,
+        alias_name: alias_name?,
+        remove_span: Span::new(as_region_start?, end),
+    })
+}
+
+/// Find the last identifier token within a node (e.g., `table.col` → `col`).
+fn find_last_identifier_in(segment: &Segment) -> Option<String> {
+    let mut result = None;
+    for child in segment.children() {
+        let st = child.segment_type();
+        if st == SegmentType::Identifier || st == SegmentType::QuotedIdentifier {
+            if let Segment::Token(t) = child {
+                result = Some(t.token.text.to_string());
+            }
+        }
+    }
+    result
+}

--- a/crates/rigsql-rules/src/aliasing/mod.rs
+++ b/crates/rigsql-rules/src/aliasing/mod.rs
@@ -3,4 +3,7 @@ pub mod al02;
 pub mod al03;
 pub mod al04;
 pub mod al05;
+pub mod al06;
 pub mod al07;
+pub mod al08;
+pub mod al09;

--- a/crates/rigsql-rules/src/layout/lt08.rs
+++ b/crates/rigsql-rules/src/layout/lt08.rs
@@ -1,0 +1,91 @@
+use rigsql_core::SegmentType;
+
+use crate::rule::{CrawlType, Rule, RuleContext, RuleGroup};
+use crate::violation::{LintViolation, SourceEdit};
+
+/// LT08: Blank line expected but not found before CTE definition.
+///
+/// Within a WITH clause, each CTE definition (after the first) should be
+/// preceded by a blank line for readability.
+#[derive(Debug, Default)]
+pub struct RuleLT08;
+
+impl Rule for RuleLT08 {
+    fn code(&self) -> &'static str {
+        "LT08"
+    }
+    fn name(&self) -> &'static str {
+        "layout.cte_newline"
+    }
+    fn description(&self) -> &'static str {
+        "Blank line expected but not found before CTE definition."
+    }
+    fn explanation(&self) -> &'static str {
+        "When a WITH clause contains multiple CTEs, each CTE after the first should \
+         be separated by a blank line to improve readability. A single newline between \
+         CTEs makes it harder to distinguish where one ends and the next begins."
+    }
+    fn groups(&self) -> &[RuleGroup] {
+        &[RuleGroup::Layout]
+    }
+    fn is_fixable(&self) -> bool {
+        true
+    }
+
+    fn crawl_type(&self) -> CrawlType {
+        CrawlType::Segment(vec![SegmentType::WithClause])
+    }
+
+    fn eval(&self, ctx: &RuleContext) -> Vec<LintViolation> {
+        let children = ctx.segment.children();
+        let mut violations = Vec::new();
+        let mut cte_count = 0;
+
+        for (i, child) in children.iter().enumerate() {
+            if child.segment_type() != SegmentType::CteDefinition {
+                continue;
+            }
+            cte_count += 1;
+            if cte_count <= 1 {
+                continue;
+            }
+
+            // Single backward scan: count newlines and find insertion point
+            let (newline_count, insert_offset) = scan_trivia_before(children, i);
+
+            if newline_count < 2 {
+                violations.push(LintViolation::with_fix(
+                    self.code(),
+                    "Expected blank line before CTE definition.",
+                    child.span(),
+                    vec![SourceEdit::insert(insert_offset, "\n")],
+                ));
+            }
+        }
+
+        violations
+    }
+}
+
+/// Single backward scan: count consecutive newlines before this CTE
+/// and find the insertion point (end of the nearest newline).
+fn scan_trivia_before(children: &[rigsql_core::Segment], cte_idx: usize) -> (usize, u32) {
+    let mut newline_count = 0;
+    let mut last_newline_end = children[cte_idx].span().start;
+
+    for child in children[..cte_idx].iter().rev() {
+        let st = child.segment_type();
+        if st == SegmentType::Newline {
+            newline_count += 1;
+            if newline_count == 1 {
+                last_newline_end = child.span().end;
+            }
+        } else if st.is_trivia() {
+            continue;
+        } else {
+            break;
+        }
+    }
+
+    (newline_count, last_newline_end)
+}

--- a/crates/rigsql-rules/src/layout/mod.rs
+++ b/crates/rigsql-rules/src/layout/mod.rs
@@ -5,6 +5,7 @@ pub mod lt04;
 pub mod lt05;
 pub mod lt06;
 pub mod lt07;
+pub mod lt08;
 pub mod lt09;
 pub mod lt10;
 pub mod lt11;

--- a/crates/rigsql-rules/src/lib.rs
+++ b/crates/rigsql-rules/src/lib.rs
@@ -27,6 +27,7 @@ pub fn default_rules() -> Vec<Box<dyn Rule>> {
         Box::new(layout::lt05::RuleLT05::default()),
         Box::new(layout::lt06::RuleLT06),
         Box::new(layout::lt07::RuleLT07),
+        Box::new(layout::lt08::RuleLT08),
         Box::new(layout::lt09::RuleLT09),
         Box::new(layout::lt10::RuleLT10),
         Box::new(layout::lt11::RuleLT11),
@@ -53,6 +54,9 @@ pub fn default_rules() -> Vec<Box<dyn Rule>> {
         Box::new(aliasing::al03::RuleAL03),
         Box::new(aliasing::al04::RuleAL04),
         Box::new(aliasing::al05::RuleAL05),
+        Box::new(aliasing::al06::RuleAL06),
         Box::new(aliasing::al07::RuleAL07::default()),
+        Box::new(aliasing::al08::RuleAL08),
+        Box::new(aliasing::al09::RuleAL09),
     ]
 }

--- a/crates/rigsql-rules/src/utils.rs
+++ b/crates/rigsql-rules/src/utils.rs
@@ -107,6 +107,27 @@ pub fn is_false_alias(children: &[Segment]) -> bool {
     false
 }
 
+/// Extract the alias name from an AliasExpression.
+/// The alias name is the last Identifier or QuotedIdentifier before any
+/// non-trivia, non-keyword segment (scanning from the end).
+pub fn extract_alias_name(children: &[Segment]) -> Option<String> {
+    for child in children.iter().rev() {
+        let st = child.segment_type();
+        if st == SegmentType::Identifier || st == SegmentType::QuotedIdentifier {
+            if let Segment::Token(t) = child {
+                return Some(t.token.text.to_string());
+            }
+        }
+        if st.is_trivia() {
+            continue;
+        }
+        if st != SegmentType::Keyword {
+            break;
+        }
+    }
+    None
+}
+
 /// Find a keyword by case-insensitive name in children. Returns (index, segment).
 pub fn find_keyword_in_children<'a>(
     children: &'a [Segment],


### PR DESCRIPTION
## Summary

- Add SARIF v2.1.0 and GitHub Actions annotation output formatters, enabling native GitHub Code Scanning and PR annotation workflows
- Implement the final 4 lint rules (AL06, AL08, AL09, LT08), completing all 41 planned rules from the project roadmap
- Apply code quality improvements identified during `/simplify` review: shared utility extraction, O(n²)→O(1) algorithm upgrades, and single-pass rewrites

## Changes

### New output formatters (`crates/rigsql-output/`)
- `sarif.rs`: Full SARIF v2.1.0 JSON output compatible with GitHub Code Scanning (`upload-sarif` action)
- `github.rs`: GitHub Actions workflow command formatter (`::warning file=...,line=...,col=...::message`)
- `lib.rs`: Register both formatters under `--format sarif` and `--format github`

### New lint rules (`crates/rigsql-rules/`)
- `AL06`: Subqueries in `FROM` clause must have an alias
- `AL08`: Column aliases must be unique within each `SELECT` statement (HashMap-based O(1) duplicate detection)
- `AL09`: Self-aliasing of columns is redundant — flags and auto-fixes `col AS col` patterns
- `LT08`: A blank line is required before a CTE definition — flags and auto-fixes missing blank lines

### Code quality (`/simplify` follow-up)
- Extract `extract_alias_name()` to `utils.rs`, eliminating duplication across AL04, AL08, and AL09
- AL04/AL08: Replace O(n²) nested-loop duplicate detection with `HashSet`/`HashMap` O(1) lookup
- AL06: Remove unnecessary recursive `has_select_inside` pre-check
- AL09: Merge 3 separate CST passes into a single extraction pass
- LT08: Replace double backward scan with a single `scan_trivia_before` helper; fix registration order (between LT07 and LT09)
- `cmd_lint` in CLI: construct `refs` Vec only for formats that need it (not `Human`)

## Test plan

- [ ] `cargo build --workspace` compiles without errors or warnings
- [ ] `cargo test --workspace` passes all existing tests
- [ ] `rigsql lint --format sarif <file>` produces valid SARIF v2.1.0 JSON (validate with `sarif-tools` or the GitHub schema)
- [ ] `rigsql lint --format github <file>` emits `::warning` lines consumable by GitHub Actions
- [ ] AL06 fires on `SELECT * FROM (SELECT 1)` (missing alias) and is silent on `SELECT * FROM (SELECT 1) AS t`
- [ ] AL08 fires on `SELECT a AS x, b AS x FROM t` and is silent on unique aliases
- [ ] AL09 fires and auto-fixes `SELECT col AS col FROM t` → `SELECT col FROM t`
- [ ] LT08 fires and auto-fixes missing blank line before `WITH` CTE block
- [ ] `rigsql rules` lists all 41 rules including AL06, AL08, AL09, LT08

🤖 Generated with [Claude Code](https://claude.com/claude-code)