### PR TITLE
feat: parallelize lint and fix commands with rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +202,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +286,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +324,22 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -435,11 +514,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rigsql-cli"
 version = "0.2.0"
 dependencies = [
  "clap",
+ "ignore",
  "miette",
+ "rayon",
  "rigsql-config",
  "rigsql-core",
  "rigsql-dialects",
@@ -547,6 +665,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -813,6 +940,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +999,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/rigsql-cli/Cargo.toml
+++ b/crates/rigsql-cli/Cargo.toml
@@ -22,3 +22,5 @@ clap = { workspace = true }
 miette = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
+rayon = { workspace = true }
+ignore = { workspace = true }

--- a/crates/rigsql-cli/src/main.rs
+++ b/crates/rigsql-cli/src/main.rs
@@ -1,8 +1,5 @@
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process;
-
 use clap::{Parser, Subcommand, ValueEnum};
+use rayon::prelude::*;
 use rigsql_config::{filter_noqa, Config};
 use rigsql_core::Segment;
 use rigsql_dialects::DialectKind;
@@ -12,6 +9,9 @@ use rigsql_rules::{
     rule::{apply_fixes, lint},
     Rule,
 };
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process;
 
 #[derive(Parser)]
 #[command(name = "rigsql", version, about = "Fast SQL linter written in Rust")]
@@ -99,7 +99,7 @@ enum ParseFormat {
     Json,
 }
 
-#[derive(Clone, ValueEnum)]
+#[derive(Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum LintFormat {
     Human,
     Json,
@@ -190,86 +190,13 @@ fn build_rules(files: &[String]) -> Vec<Box<dyn Rule>> {
     rules
 }
 
-fn cmd_fix(files: &[String], dialect: DialectKind, dry_run: bool, _force: bool) -> i32 {
-    let sql_files = collect_sql_files(files);
-    if sql_files.is_empty() {
-        eprintln!("No SQL files found.");
-        return 2;
-    }
-
-    let all_rules = build_rules(files);
-    let parser = dialect.parser();
-    let dialect_str = dialect.as_str();
-    let mut fixed_count = 0;
-    let mut file_count = 0;
-
-    for path in &sql_files {
-        let source = match fs::read_to_string(path) {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("Error reading {}: {}", path.display(), e);
-                continue;
-            }
-        };
-
-        // Iterative fix loop: parse → lint → fix → repeat until stable (max 10 rounds)
-        let mut current = source.clone();
-        let mut rounds = 0;
-        let max_rounds = 10;
-
-        while let Ok(cst) = parser.parse(&current) {
-            let mut violations = lint(&cst, &current, &all_rules, dialect_str);
-            filter_noqa(&current, &mut violations);
-
-            // Only keep fixable violations (those with edits)
-            let fixable: Vec<_> = violations
-                .into_iter()
-                .filter(|v| !v.fixes.is_empty())
-                .collect();
-            if fixable.is_empty() {
-                break;
-            }
-
-            let new_source = apply_fixes(&current, &fixable);
-            if new_source == current {
-                break; // No progress
-            }
-
-            fixed_count += fixable.len();
-            current = new_source;
-            rounds += 1;
-            if rounds >= max_rounds {
-                break;
-            }
-        }
-
-        if current != source {
-            file_count += 1;
-            if dry_run {
-                println!("Would fix: {}", path.display());
-            } else {
-                if let Err(e) = fs::write(path, &current) {
-                    eprintln!("Error writing {}: {}", path.display(), e);
-                } else {
-                    println!("Fixed: {}", path.display());
-                }
-            }
-        }
-    }
-
-    if file_count == 0 {
-        eprintln!("No fixable violations found.");
-    } else {
-        eprintln!(
-            "{} {} in {} file{}.",
-            if dry_run { "Would apply" } else { "Applied" },
-            fixed_count,
-            file_count,
-            if file_count == 1 { "" } else { "s" },
-        );
-    }
-
-    0
+/// Per-file lint result for aggregation after parallel processing.
+struct FileLintResult {
+    path: PathBuf,
+    source: String,
+    violations: Vec<rigsql_rules::LintViolation>,
+    /// Pre-formatted output for human format (avoids post-processing).
+    human_output: Option<String>,
 }
 
 fn cmd_lint(files: &[String], dialect: DialectKind, format: LintFormat, no_color: bool) -> i32 {
@@ -280,65 +207,78 @@ fn cmd_lint(files: &[String], dialect: DialectKind, format: LintFormat, no_color
     }
 
     let rules = build_rules(files);
-
-    let parser = dialect.parser();
     let dialect_str = dialect.as_str();
     let formatter = HumanFormatter::new(!no_color);
 
+    // Parallel lint: each file is parsed + linted independently
+    let results: Vec<FileLintResult> = sql_files
+        .par_iter()
+        .filter_map(|path| {
+            let source = match fs::read_to_string(path) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("Error reading {}: {}", path.display(), e);
+                    return None;
+                }
+            };
+
+            let parser = dialect.parser();
+            let cst = match parser.parse(&source) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("Parse error in {}: {}", path.display(), e);
+                    return None;
+                }
+            };
+
+            let mut violations = lint(&cst, &source, &rules, dialect_str);
+            filter_noqa(&source, &mut violations);
+
+            let human_output = if format == LintFormat::Human {
+                let out = formatter.format_file(path, &source, &violations);
+                Some(out)
+            } else {
+                None
+            };
+
+            Some(FileLintResult {
+                path: path.clone(),
+                source,
+                violations,
+                human_output,
+            })
+        })
+        .collect();
+
+    // Aggregate results (sequential, for deterministic output order)
+    let file_count = sql_files.len();
     let mut total_violations = 0;
     let mut files_with_violations = 0;
-    let mut json_results: Vec<(PathBuf, String, Vec<rigsql_rules::LintViolation>)> = Vec::new();
 
-    for path in &sql_files {
-        let source = match fs::read_to_string(path) {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("Error reading {}: {}", path.display(), e);
-                continue;
-            }
-        };
-
-        let cst = match parser.parse(&source) {
-            Ok(c) => c,
-            Err(e) => {
-                eprintln!("Parse error in {}: {}", path.display(), e);
-                continue;
-            }
-        };
-
-        let mut violations = lint(&cst, &source, &rules, dialect_str);
-
-        // Apply noqa filtering
-        filter_noqa(&source, &mut violations);
-
-        if !violations.is_empty() {
+    for r in &results {
+        if !r.violations.is_empty() {
             files_with_violations += 1;
-            total_violations += violations.len();
-        }
-
-        match format {
-            LintFormat::Human => {
-                let output = formatter.format_file(path, &source, &violations);
-                if !output.is_empty() {
-                    print!("{output}");
-                }
-            }
-            LintFormat::Json | LintFormat::Sarif | LintFormat::Github => {
-                json_results.push((path.clone(), source, violations));
-            }
+            total_violations += r.violations.len();
         }
     }
 
     match format {
         LintFormat::Human => {
+            for r in &results {
+                if let Some(out) = &r.human_output {
+                    if !out.is_empty() {
+                        print!("{out}");
+                    }
+                }
+            }
             let summary =
-                formatter.format_summary(sql_files.len(), files_with_violations, total_violations);
+                formatter.format_summary(file_count, files_with_violations, total_violations);
             print!("{summary}");
         }
         LintFormat::Json | LintFormat::Sarif | LintFormat::Github => {
-            let refs: Vec<(&Path, &str, &[rigsql_rules::LintViolation])> = json_results
+            let refs: Vec<(&Path, &str, &[rigsql_rules::LintViolation])> = results
                 .iter()
-                .map(|(p, s, v)| (p.as_path(), s.as_str(), v.as_slice()))
+                .map(|r| (r.path.as_path(), r.source.as_str(), r.violations.as_slice()))
                 .collect();
             match format {
                 LintFormat::Json => {
@@ -368,6 +308,107 @@ fn cmd_lint(files: &[String], dialect: DialectKind, format: LintFormat, no_color
     }
 }
 
+/// Per-file fix result.
+struct FileFixResult {
+    path: PathBuf,
+    fixed: String,
+    fix_count: usize,
+}
+
+fn cmd_fix(files: &[String], dialect: DialectKind, dry_run: bool, _force: bool) -> i32 {
+    let sql_files = collect_sql_files(files);
+    if sql_files.is_empty() {
+        eprintln!("No SQL files found.");
+        return 2;
+    }
+
+    let all_rules = build_rules(files);
+    let dialect_str = dialect.as_str();
+
+    // Parallel fix: each file runs its own iterative fix loop
+    let results: Vec<FileFixResult> = sql_files
+        .par_iter()
+        .filter_map(|path| {
+            let source = match fs::read_to_string(path) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("Error reading {}: {}", path.display(), e);
+                    return None;
+                }
+            };
+
+            let parser = dialect.parser();
+            let mut current = source;
+            let mut total_fixed = 0;
+            let max_rounds = 10;
+
+            for _ in 0..max_rounds {
+                let cst = match parser.parse(&current) {
+                    Ok(c) => c,
+                    Err(_) => break,
+                };
+
+                let mut violations = lint(&cst, &current, &all_rules, dialect_str);
+                filter_noqa(&current, &mut violations);
+
+                let fixable: Vec<_> = violations
+                    .into_iter()
+                    .filter(|v| !v.fixes.is_empty())
+                    .collect();
+                if fixable.is_empty() {
+                    break;
+                }
+
+                let new_source = apply_fixes(&current, &fixable);
+                if new_source == current {
+                    break;
+                }
+
+                total_fixed += fixable.len();
+                current = new_source;
+            }
+
+            if total_fixed == 0 {
+                return None;
+            }
+
+            Some(FileFixResult {
+                path: path.clone(),
+                fixed: current,
+                fix_count: total_fixed,
+            })
+        })
+        .collect();
+
+    let file_count = results.len();
+    let mut total_fixed = 0;
+
+    for r in &results {
+        total_fixed += r.fix_count;
+        if dry_run {
+            println!("Would fix: {}", r.path.display());
+        } else if let Err(e) = fs::write(&r.path, &r.fixed) {
+            eprintln!("Error writing {}: {}", r.path.display(), e);
+        } else {
+            println!("Fixed: {}", r.path.display());
+        }
+    }
+
+    if file_count == 0 {
+        eprintln!("No fixable violations found.");
+    } else {
+        eprintln!(
+            "{} {} in {} file{}.",
+            if dry_run { "Would apply" } else { "Applied" },
+            total_fixed,
+            file_count,
+            if file_count == 1 { "" } else { "s" },
+        );
+    }
+
+    0
+}
+
 fn cmd_rules() {
     let rules = default_rules();
     println!("{:<6} {:<30} Description", "Code", "Name");
@@ -389,24 +430,20 @@ fn collect_sql_files(paths: &[String]) -> Vec<PathBuf> {
         if path.is_file() {
             files.push(path);
         } else if path.is_dir() {
-            walk_dir_recursive(&path, &mut files);
+            let walker = ignore::WalkBuilder::new(&path)
+                .hidden(true) // skip hidden files
+                .git_ignore(true) // respect .gitignore
+                .build();
+            for entry in walker.flatten() {
+                let p = entry.path().to_path_buf();
+                if p.is_file() && p.extension().is_some_and(|ext| ext == "sql") {
+                    files.push(p);
+                }
+            }
         }
     }
     files.sort();
     files
-}
-
-fn walk_dir_recursive(dir: &Path, files: &mut Vec<PathBuf>) {
-    if let Ok(entries) = fs::read_dir(dir) {
-        for entry in entries.flatten() {
-            let p = entry.path();
-            if p.is_dir() {
-                walk_dir_recursive(&p, files);
-            } else if p.is_file() && p.extension().is_some_and(|ext| ext == "sql") {
-                files.push(p);
-            }
-        }
-    }
 }
 
 fn read_file_or_stdin(file: &str) -> String {


### PR DESCRIPTION
## Summary

- Add `rayon` and `ignore` crate dependencies to `rigsql-cli`
- Rewrite `cmd_lint` and `cmd_fix` to process files in parallel via `rayon::par_iter()`, collecting results into `FileLintResult` / `FileFixResult` structs before printing
- Replace the hand-rolled `walk_dir_recursive` with `ignore::WalkBuilder`, which automatically respects `.gitignore` rules
- Each worker thread instantiates its own `Parser` (safe because `DialectKind` is `Copy`)
- Human-format output is pre-rendered per-file in parallel and then printed sequentially, ensuring deterministic ordering regardless of thread scheduling
- Derive `Copy`, `PartialEq`, `Eq` on `LintFormat` so it can be captured freely in closures across threads
- Remove the now-unnecessary `source.clone()` in `cmd_fix` by checking `total_fixed == 0` instead

This is Phase 5 item 1 of the project plan (Polish – rayon parallelization).

## Changes

| File | Change |
|------|--------|
| `crates/rigsql-cli/Cargo.toml` | Add `rayon` and `ignore` workspace dependencies |
| `crates/rigsql-cli/src/main.rs` | Parallel lint/fix, WalkBuilder, FileLintResult/FileFixResult, LintFormat derives |
| `Cargo.lock` | Updated with rayon, ignore, crossbeam, etc. |

## Test plan

- [ ] `cargo build --release` succeeds without warnings
- [ ] `rigsql lint <single-file>` produces identical output to the previous implementation
- [ ] `rigsql lint <directory>` correctly traverses subdirectories and skips `.gitignore`d paths
- [ ] `rigsql lint --format json <directory>` produces valid JSON
- [ ] `rigsql fix <directory>` applies fixes and reports the correct count
- [ ] Running against a large SQL corpus shows measurable speedup compared to `main`