### PR TITLE
Add shell completions and GitHub Action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +564,7 @@ name = "rigsql-cli"
 version = "0.2.0"
 dependencies = [
  "clap",
+ "clap_complete",
  "ignore",
  "miette",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rigsql-output = { path = "crates/rigsql-output", version = "0.2.0" }
 
 # External dependencies
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 smol_str = { version = "0.3", features = ["serde"] }

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,39 @@
+name: "rigsql SQL Linter"
+description: "Fast SQL linter with sqlfluff-compatible rules, written in Rust"
+branding:
+  icon: "check-circle"
+  color: "blue"
+
+inputs:
+  paths:
+    description: "Files or directories to lint (space-separated)"
+    required: false
+    default: "."
+  dialect:
+    description: "SQL dialect (ansi, postgres, tsql)"
+    required: false
+    default: "ansi"
+  format:
+    description: "Output format (human, json, sarif, github)"
+    required: false
+    default: "github"
+  version:
+    description: "rigsql version to install (e.g. 0.2.0, or 'latest')"
+    required: false
+    default: "latest"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install rigsql
+      shell: bash
+      run: |
+        if [ "${{ inputs.version }}" = "latest" ]; then
+          cargo install rigsql-cli
+        else
+          cargo install rigsql-cli --version "${{ inputs.version }}"
+        fi
+
+    - name: Run rigsql lint
+      shell: bash
+      run: rigsql lint ${{ inputs.paths }} --dialect ${{ inputs.dialect }} --format ${{ inputs.format }}

--- a/crates/rigsql-cli/Cargo.toml
+++ b/crates/rigsql-cli/Cargo.toml
@@ -19,6 +19,7 @@ rigsql-rules = { workspace = true }
 rigsql-config = { workspace = true }
 rigsql-output = { workspace = true }
 clap = { workspace = true }
+clap_complete = { workspace = true }
 miette = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }

--- a/crates/rigsql-cli/src/main.rs
+++ b/crates/rigsql-cli/src/main.rs
@@ -1,4 +1,5 @@
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use clap_complete::Shell;
 use rayon::prelude::*;
 use rigsql_config::{filter_noqa, Config};
 use rigsql_core::Segment;
@@ -74,6 +75,12 @@ enum Commands {
 
     /// List available lint rules
     Rules,
+
+    /// Generate shell completions
+    Completions {
+        /// Shell to generate completions for
+        shell: Shell,
+    },
 }
 
 #[derive(Clone, ValueEnum)]
@@ -138,6 +145,10 @@ fn main() {
         }
 
         Commands::Rules => cmd_rules(),
+
+        Commands::Completions { shell } => {
+            clap_complete::generate(shell, &mut Cli::command(), "rigsql", &mut std::io::stdout());
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `rigsql completions <shell>` subcommand powered by `clap_complete`
- Supports bash, zsh, fish, elvish, and powershell completion scripts
- Add `action.yml` to enable rigsql as a GitHub Marketplace Action

## Changes

- `Cargo.toml` / `Cargo.lock`: add `clap_complete` dependency
- `crates/rigsql-cli/Cargo.toml`: declare `clap_complete` in the CLI crate
- `crates/rigsql-cli/src/main.rs`: implement `completions` subcommand that writes the generated script to stdout
- `action.yml`: GitHub Action definition for Marketplace integration

## Test plan

- [ ] `cargo build` succeeds with no errors
- [ ] `rigsql completions bash` outputs a valid bash completion script
- [ ] `rigsql completions zsh` outputs a valid zsh completion script
- [ ] `rigsql completions fish` outputs a valid fish completion script
- [ ] `rigsql completions powershell` outputs a valid PowerShell completion script
- [ ] Sourcing the bash/zsh script in a shell enables tab-completion for `rigsql` subcommands and flags
- [ ] `action.yml` is parseable by the GitHub Actions runner (`act` or a real workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)