### PR TITLE
Release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rigsql-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-config"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "rigsql-core",
  "rigsql-rules",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "smol_str",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-dialects"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "rigsql-core",
  "rigsql-lexer",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-lexer"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "insta",
  "rigsql-core",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-output"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "miette",
  "rigsql-core",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-parser"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "insta",
  "rigsql-core",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-rules"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "insta",
  "rigsql-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"
@@ -23,13 +23,13 @@ keywords = ["sql", "linter", "sqlfluff", "tsql", "postgres"]
 
 [workspace.dependencies]
 # Internal crates
-rigsql-core = { path = "crates/rigsql-core", version = "0.2.0" }
-rigsql-lexer = { path = "crates/rigsql-lexer", version = "0.2.0" }
-rigsql-parser = { path = "crates/rigsql-parser", version = "0.2.0" }
-rigsql-dialects = { path = "crates/rigsql-dialects", version = "0.2.0" }
-rigsql-rules = { path = "crates/rigsql-rules", version = "0.2.0" }
-rigsql-config = { path = "crates/rigsql-config", version = "0.2.0" }
-rigsql-output = { path = "crates/rigsql-output", version = "0.2.0" }
+rigsql-core = { path = "crates/rigsql-core", version = "0.3.0" }
+rigsql-lexer = { path = "crates/rigsql-lexer", version = "0.3.0" }
+rigsql-parser = { path = "crates/rigsql-parser", version = "0.3.0" }
+rigsql-dialects = { path = "crates/rigsql-dialects", version = "0.3.0" }
+rigsql-rules = { path = "crates/rigsql-rules", version = "0.3.0" }
+rigsql-config = { path = "crates/rigsql-config", version = "0.3.0" }
+rigsql-output = { path = "crates/rigsql-output", version = "0.3.0" }
 
 # External dependencies
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -5,13 +5,19 @@ Fast SQL linter written in Rust. sqlfluff-compatible rule codes with AI-friendly
 ## Features
 
 - Custom CST (Concrete Syntax Tree) parser — preserves all whitespace and comments
+- Error recovery — produces partial CSTs even for invalid SQL
 - sqlfluff-compatible rule code system (CP01, LT01, AL01, etc.)
+- 41 rules across 4 categories: Capitalisation, Layout, Convention, Aliasing
 - AI-friendly JSON output with rule explanations, context, and source lines
 - Multi-dialect support: ANSI, PostgreSQL, SQL Server (TSQL)
 - Auto-fix for many rules (`rigsql fix`)
+- Parallel file processing via rayon
 - Configuration via `rigsql.toml` or `.sqlfluff` (compatible)
+- Inline `-- noqa` comments to suppress violations
 - Recursive directory scanning with `.gitignore` support
-- Full Unicode support (Japanese identifiers, comments, etc.)
+- Shell completions for bash, zsh, fish, elvish, powershell
+- GitHub Action for CI integration
+- Multiple output formats: human, JSON, SARIF, GitHub Annotations
 
 ## Installation
 
@@ -45,8 +51,17 @@ rigsql fix ./queries/
 # JSON output (for CI/AI tools)
 rigsql lint ./queries/ --format json
 
+# SARIF output (for IDE integration)
+rigsql lint ./queries/ --format sarif
+
+# GitHub Annotations (for CI)
+rigsql lint ./queries/ --format github
+
 # View the CST of a SQL file
 rigsql parse query.sql
+
+# Generate shell completions
+rigsql completions zsh > _rigsql
 ```
 
 ## Usage
@@ -55,10 +70,11 @@ rigsql parse query.sql
 rigsql <COMMAND>
 
 Commands:
-  lint    Lint SQL files for style violations
-  fix     Auto-fix SQL files
-  parse   Parse SQL files and display the Concrete Syntax Tree
-  rules   List available lint rules
+  lint         Lint SQL files for style violations
+  fix          Auto-fix SQL files
+  parse        Parse SQL files and display the Concrete Syntax Tree
+  rules        List available lint rules
+  completions  Generate shell completions
 ```
 
 ### `rigsql lint`
@@ -71,7 +87,7 @@ Arguments:
 
 Options:
   --dialect <DIALECT>  SQL dialect [default: ansi] [possible values: ansi, postgres, tsql]
-  --format <FORMAT>    Output format [default: human] [possible values: human, json]
+  --format <FORMAT>    Output format [default: human] [possible values: human, json, sarif, github]
   --no-color           Disable colored output
 ```
 
@@ -85,6 +101,8 @@ Arguments:
 
 Options:
   --dialect <DIALECT>  SQL dialect [default: ansi] [possible values: ansi, postgres, tsql]
+  --dry-run            Don't write changes, just show what would be fixed
+  -f, --force          Skip confirmation prompt
 ```
 
 ### `rigsql parse`
@@ -100,9 +118,18 @@ Options:
   --format <FORMAT>    Output format [default: tree] [possible values: tree, json]
 ```
 
+### `rigsql completions`
+
+```
+rigsql completions <SHELL>
+
+Arguments:
+  <SHELL>  Shell to generate completions for [possible values: bash, elvish, fish, powershell, zsh]
+```
+
 ## Rules
 
-38 rules across 4 categories, compatible with sqlfluff rule codes.
+41 rules across 4 categories, compatible with sqlfluff rule codes.
 
 ### Capitalisation (CP)
 
@@ -125,6 +152,7 @@ Options:
 | LT05 | layout.long_lines | Line too long (default: 80 characters) |
 | LT06 | layout.function_paren | Function name not followed immediately by parenthesis |
 | LT07 | layout.with_spacing | WITH keyword not followed by single space |
+| LT08 | layout.cte_newline | Blank line expected but not found before CTE definition |
 | LT09 | layout.select_targets | Select targets should be on a new line unless there is only one |
 | LT10 | layout.select_modifier | SELECT modifiers (DISTINCT, ALL) must be on same line as SELECT |
 | LT11 | layout.set_operator_newline | Set operators should be surrounded by newlines |
@@ -159,7 +187,10 @@ Options:
 | AL03 | aliasing.expression | Column expression without alias |
 | AL04 | aliasing.unique_table | Table aliases should be unique within a statement |
 | AL05 | aliasing.unused | Tables/CTEs should not be unused |
+| AL06 | aliasing.subquery | Subqueries in FROM clause should have an alias |
 | AL07 | aliasing.table_naming | Table aliases should follow a naming convention |
+| AL08 | aliasing.unique_column | Column aliases should be unique within each statement |
+| AL09 | aliasing.self_alias | Self-aliasing of columns is redundant |
 
 ## Configuration
 
@@ -195,6 +226,15 @@ exclude_rules = LT09,CV06
 capitalisation_policy = lower
 ```
 
+### Inline noqa
+
+```sql
+SELECT
+    col1,  -- noqa: CP01
+    col2
+FROM my_table;  -- noqa
+```
+
 ## Output Examples
 
 ### Human (default)
@@ -217,7 +257,7 @@ Found 5 violation(s) in 1 file(s) (1 file(s) scanned).
   "version": "1.0",
   "tool": {
     "name": "rigsql",
-    "version": "0.1.0"
+    "version": "0.3.0"
   },
   "summary": {
     "files_scanned": 1,
@@ -247,6 +287,16 @@ Found 5 violation(s) in 1 file(s) (1 file(s) scanned).
 }
 ```
 
+## GitHub Action
+
+```yaml
+- uses: yukonsky/rigsql@v0.3.0
+  with:
+    paths: "./queries/"
+    dialect: "ansi"
+    format: "github"
+```
+
 ## Exit Codes
 
 | Code | Meaning |
@@ -265,7 +315,7 @@ crates/
   rigsql-dialects/  # ANSI, PostgreSQL, TSQL dialect definitions
   rigsql-rules/     # All lint rules (CP, LT, CV, AL)
   rigsql-config/    # Configuration loading (.sqlfluff, rigsql.toml)
-  rigsql-output/    # Human + JSON formatters
+  rigsql-output/    # Human, JSON, SARIF, GitHub Annotation formatters
   rigsql-cli/       # CLI binary
 ```
 


### PR DESCRIPTION
## Summary

This PR prepares the v0.3.0 release of rigsql, a fast SQL linter written in Rust with sqlfluff-compatible rule codes and AI-friendly output.

## What's New in v0.3.0

### Rules
- **41 rules** across 4 categories (CP01-05, LT01-15, CV01-12, AL01-09)
- New rules added: LT08 (CTE newline), AL06 (subquery alias), AL08 (unique column alias), AL09 (self-alias)

### New Commands & Features
- **Shell completions** via `rigsql completions <shell>` — supports bash, zsh, fish, elvish, powershell
- **GitHub Action** (`action.yml`) for easy CI integration via `yukonsky/rigsql@v0.3.0`
- **SARIF output format** for IDE integration (`--format sarif`)
- **GitHub Annotations format** for CI pipelines (`--format github`)
- **Inline `-- noqa` support** to suppress specific violations per line
- **Error recovery** — produces partial CSTs even for invalid SQL
- **Parallel file processing** via rayon for improved performance
- **`--dry-run` and `--force` flags** for the `fix` command

### Configuration
- Configuration via `rigsql.toml` or `.sqlfluff` (compatible)
- Inline `-- noqa` and `-- noqa: RULE` suppression support

## Changes in This PR

- Bump version `0.2.0` → `0.3.0` across all 8 workspace crates (`Cargo.toml`, `Cargo.lock`)
- Update `README.md` with all 41 rules, new CLI commands, output formats, GitHub Action usage, and noqa documentation

## Test Plan

- [ ] `cargo test --workspace` passes
- [ ] `cargo build --release` succeeds
- [ ] `rigsql completions zsh` outputs valid zsh completion script
- [ ] GitHub Action `action.yml` works in a sample workflow
- [ ] All 41 rules listed in `rigsql rules` output