### PR TITLE
security: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `permissions: contents: read` to `ci.yml` and `publish.yml`
- Restricts GITHUB_TOKEN scope following the principle of least privilege

## Resolved Alerts

- [#1](https://github.com/yukonsky/rigsql/security/code-scanning/1) — ci.yml test job
- [#2](https://github.com/yukonsky/rigsql/security/code-scanning/2) — publish.yml publish job
- [#3](https://github.com/yukonsky/rigsql/security/code-scanning/3) — ci.yml clippy job
- [#4](https://github.com/yukonsky/rigsql/security/code-scanning/4) — ci.yml fmt job

## Test plan

- [x] CI workflows still run correctly (read-only access is sufficient)
- [x] Publish workflow uses `CARGO_REGISTRY_TOKEN` via secrets, not GITHUB_TOKEN write

🤖 Generated with [Claude Code](https://claude.com/claude-code)