### PR TITLE
ci: cross-platform binary releases and fast GitHub Action install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish to crates.io
+name: Release
 
 on:
   push:
@@ -6,16 +6,105 @@ on:
       - "v*"
 
 permissions:
-  contents: read
+  contents: write
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
 jobs:
+  # ── Build cross-platform binaries in parallel ──
+  build:
+    name: Build (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-13
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release -p rigsql-cli
+
+      - name: Package (Unix)
+        if: matrix.archive == 'tar.gz'
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          ASSET_NAME="rigsql-${TAG}-${{ matrix.target }}.tar.gz"
+          tar czf "${ASSET_NAME}" -C target/release rigsql
+          sha256sum "${ASSET_NAME}" > "${ASSET_NAME}.sha256"
+          echo "ASSET_NAME=${ASSET_NAME}" >> "$GITHUB_ENV"
+
+      - name: Package (Windows)
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: |
+          $tag = "${{ github.ref_name }}"
+          $assetName = "rigsql-${tag}-${{ matrix.target }}.zip"
+          Compress-Archive -Path "target/release/rigsql.exe" -DestinationPath $assetName
+          $hash = (Get-FileHash $assetName -Algorithm SHA256).Hash.ToLower()
+          "$hash  $assetName" | Out-File -Encoding utf8 "${assetName}.sha256"
+          "ASSET_NAME=$assetName" | Out-File -Append $env:GITHUB_ENV
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: |
+            rigsql-*.${{ matrix.archive }}
+            rigsql-*.${{ matrix.archive }}.sha256
+
+  # ── Create GitHub Release with all binaries ──
+  release:
+    name: GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          cat *.sha256 > checksums.txt
+          echo "Checksums:"
+          cat checksums.txt
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            rigsql-*.tar.gz
+            rigsql-*.zip
+            checksums.txt
+
+  # ── Publish to crates.io ──
   publish:
-    name: Publish
+    name: Publish to crates.io
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -33,9 +122,6 @@ jobs:
       - name: Run tests
         run: cargo test --workspace
 
-      # Publish in dependency order — each crate needs its dependencies on crates.io first.
-      # Skips already-published crates (safe for rerun).
-      # On rate limit (429), parses the "try again after" timestamp and waits.
       - name: Publish all crates
         run: |
           PUBLISHED=false
@@ -95,6 +181,7 @@ jobs:
             rigsql-lexer
             rigsql-parser
             rigsql-dialects
+            rigsql-i18n
             rigsql-rules
             rigsql-config
             rigsql-output

--- a/action.yml
+++ b/action.yml
@@ -18,20 +18,70 @@ inputs:
     required: false
     default: "github"
   version:
-    description: "rigsql version to install (e.g. 0.2.0, or 'latest')"
+    description: "rigsql version to install (e.g. 0.4.1, or 'latest')"
     required: false
     default: "latest"
+  token:
+    description: "GitHub token for downloading release assets (defaults to github.token)"
+    required: false
+    default: ${{ github.token }}
 
 runs:
   using: "composite"
   steps:
     - name: Install rigsql
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
       run: |
+        set -euo pipefail
+
+        # Determine version tag
         if [ "${{ inputs.version }}" = "latest" ]; then
-          cargo install rigsql-cli
+          TAG=$(gh release view --repo yukonsky/rigsql --json tagName -q .tagName 2>/dev/null || echo "")
         else
-          cargo install rigsql-cli --version "${{ inputs.version }}"
+          TAG="v${{ inputs.version }}"
+        fi
+
+        # Determine target triple
+        case "$RUNNER_OS-$RUNNER_ARCH" in
+          Linux-X64)    TARGET="x86_64-unknown-linux-gnu" ;  EXT="tar.gz" ;;
+          Linux-ARM64)  TARGET="aarch64-unknown-linux-gnu" ; EXT="tar.gz" ;;
+          macOS-X64)    TARGET="x86_64-apple-darwin" ;        EXT="tar.gz" ;;
+          macOS-ARM64)  TARGET="aarch64-apple-darwin" ;       EXT="tar.gz" ;;
+          Windows-X64)  TARGET="x86_64-pc-windows-msvc" ;    EXT="zip" ;;
+          *)            TARGET="" ;;
+        esac
+
+        INSTALLED=false
+
+        # Try downloading pre-built binary
+        if [ -n "$TAG" ] && [ -n "$TARGET" ]; then
+          ASSET="rigsql-${TAG}-${TARGET}.${EXT}"
+          echo "Downloading ${ASSET} from GitHub Releases..."
+          if gh release download "$TAG" --repo yukonsky/rigsql --pattern "$ASSET" 2>/dev/null; then
+            if [ "$EXT" = "tar.gz" ]; then
+              tar xzf "$ASSET"
+              install -m 755 rigsql /usr/local/bin/rigsql
+            else
+              unzip -o "$ASSET"
+              mv rigsql.exe "${RUNNER_TEMP}/rigsql.exe"
+              echo "${RUNNER_TEMP}" >> "$GITHUB_PATH"
+            fi
+            rm -f "$ASSET"
+            INSTALLED=true
+            echo "rigsql installed from pre-built binary"
+          fi
+        fi
+
+        # Fallback to cargo install
+        if [ "$INSTALLED" = false ]; then
+          echo "Pre-built binary not available, falling back to cargo install..."
+          if [ "${{ inputs.version }}" = "latest" ]; then
+            cargo install rigsql-cli
+          else
+            cargo install rigsql-cli --version "${{ inputs.version }}"
+          fi
         fi
 
     - name: Run rigsql lint


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` that builds pre-built binaries for 5 targets on every `v*` tag push, creates a GitHub Release with archives + `checksums.txt`, and publishes all crates to crates.io — replacing the old `publish.yml`.
- Update `action.yml` to download the matching pre-built binary from GitHub Releases instead of compiling via `cargo install`, cutting install time from several minutes to a few seconds. Falls back to `cargo install` when no binary is available.
- Delete `.github/workflows/publish.yml` (absorbed into `release.yml`).

## Target platforms

| Target | OS | Archive |
|---|---|---|
| `x86_64-unknown-linux-gnu` | `ubuntu-latest` | `.tar.gz` |
| `aarch64-unknown-linux-gnu` | `ubuntu-24.04-arm` | `.tar.gz` |
| `x86_64-apple-darwin` | `macos-13` | `.tar.gz` |
| `aarch64-apple-darwin` | `macos-latest` | `.tar.gz` |
| `x86_64-pc-windows-msvc` | `windows-latest` | `.zip` |

## How it works

On `v*` tag push:
1. **build** job — parallel matrix builds each target, packages the binary, uploads as an artifact with a SHA-256 checksum.
2. **release** job — downloads all artifacts, concatenates checksums into `checksums.txt`, creates a GitHub Release via `softprops/action-gh-release`.
3. **publish** job — verifies the tag version matches `Cargo.toml`, runs tests, publishes all 9 crates to crates.io in dependency order with rate-limit handling.

`action.yml` detects `$RUNNER_OS`/`$RUNNER_ARCH`, downloads the correct archive with `gh release download`, extracts it to `/usr/local/bin` (Unix) or `$RUNNER_TEMP` (Windows), and falls back to `cargo install` if the binary is missing.

## Test plan

- [ ] Push a `v*` tag and verify all 5 build jobs succeed and produce release assets.
- [ ] Confirm `checksums.txt` is attached to the GitHub Release.
- [ ] Use the action in a test workflow and verify rigsql is installed in seconds.
- [ ] Verify the fallback path (`cargo install`) works when specifying an unreleased version.