### PR TITLE
release: bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rigsql-cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-config"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "rigsql-core",
  "rigsql-rules",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "serde",
  "smol_str",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-dialects"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "rigsql-core",
  "rigsql-lexer",
@@ -687,14 +687,14 @@ dependencies = [
 
 [[package]]
 name = "rigsql-i18n"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "rust-i18n",
 ]
 
 [[package]]
 name = "rigsql-lexer"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "insta",
  "rigsql-core",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-output"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "miette",
  "rigsql-core",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-parser"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "insta",
  "rigsql-core",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-rules"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "insta",
  "rigsql-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"
@@ -24,14 +24,14 @@ keywords = ["sql", "linter", "sqlfluff", "tsql", "postgres"]
 
 [workspace.dependencies]
 # Internal crates
-rigsql-core = { path = "crates/rigsql-core", version = "0.4.1" }
-rigsql-lexer = { path = "crates/rigsql-lexer", version = "0.4.1" }
-rigsql-parser = { path = "crates/rigsql-parser", version = "0.4.1" }
-rigsql-dialects = { path = "crates/rigsql-dialects", version = "0.4.1" }
-rigsql-rules = { path = "crates/rigsql-rules", version = "0.4.1" }
-rigsql-config = { path = "crates/rigsql-config", version = "0.4.1" }
-rigsql-output = { path = "crates/rigsql-output", version = "0.4.1" }
-rigsql-i18n = { path = "crates/rigsql-i18n", version = "0.4.1" }
+rigsql-core = { path = "crates/rigsql-core", version = "0.5.0" }
+rigsql-lexer = { path = "crates/rigsql-lexer", version = "0.5.0" }
+rigsql-parser = { path = "crates/rigsql-parser", version = "0.5.0" }
+rigsql-dialects = { path = "crates/rigsql-dialects", version = "0.5.0" }
+rigsql-rules = { path = "crates/rigsql-rules", version = "0.5.0" }
+rigsql-config = { path = "crates/rigsql-config", version = "0.5.0" }
+rigsql-output = { path = "crates/rigsql-output", version = "0.5.0" }
+rigsql-i18n = { path = "crates/rigsql-i18n", version = "0.5.0" }
 
 # External dependencies
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Fast SQL linter written in Rust. sqlfluff-compatible rule codes with AI-friendly
 - 75 rules across 9 categories: Capitalisation, Layout, Convention, Aliasing, Ambiguous, References, Structure, TSQL, Rigsql
 - AI-friendly JSON output with rule explanations, context, and source lines
 - Multi-dialect support: ANSI, PostgreSQL, SQL Server (TSQL)
+- i18n support — violation messages in English and Japanese (`--locale en|ja`)
 - Auto-fix for many rules (`rigsql fix`)
 - Parallel file processing via rayon
 - Configuration via `rigsql.toml` or `.sqlfluff` (compatible)
@@ -44,6 +45,9 @@ rigsql lint ./queries/
 
 # Lint with SQL Server dialect
 rigsql lint ./queries/ --dialect tsql
+
+# Lint with Japanese violation messages
+rigsql lint ./queries/ --locale ja
 
 # Auto-fix violations
 rigsql fix ./queries/
@@ -87,6 +91,7 @@ Arguments:
 
 Options:
   --dialect <DIALECT>  SQL dialect [default: ansi] [possible values: ansi, postgres, tsql]
+  --locale <LOCALE>    Output locale (e.g. "en", "ja") — overrides config and system locale
   --format <FORMAT>    Output format [default: human] [possible values: human, json, sarif, github]
   --no-color           Disable colored output
 ```
@@ -101,6 +106,7 @@ Arguments:
 
 Options:
   --dialect <DIALECT>  SQL dialect [default: ansi] [possible values: ansi, postgres, tsql]
+  --locale <LOCALE>    Output locale (e.g. "en", "ja") — overrides config and system locale
   --dry-run            Don't write changes, just show what would be fixed
   -f, --force          Skip confirmation prompt
 ```
@@ -316,7 +322,7 @@ Found 5 violation(s) in 1 file(s) (1 file(s) scanned).
   "version": "1.0",
   "tool": {
     "name": "rigsql",
-    "version": "0.4.1"
+    "version": "0.5.0"
   },
   "summary": {
     "files_scanned": 1,
@@ -349,7 +355,7 @@ Found 5 violation(s) in 1 file(s) (1 file(s) scanned).
 ## GitHub Action
 
 ```yaml
-- uses: yukonsky/rigsql@v0.4.1
+- uses: yukonsky/rigsql@v0.5.0
   with:
     paths: "./queries/"
     dialect: "ansi"
@@ -375,6 +381,7 @@ crates/
   rigsql-rules/     # All lint rules (CP, LT, CV, AL, AM, RF, ST, TQ, RG)
   rigsql-config/    # Configuration loading (.sqlfluff, rigsql.toml)
   rigsql-output/    # Human, JSON, SARIF, GitHub Annotation formatters
+  rigsql-i18n/      # Internationalization (en, ja locale files)
   rigsql-cli/       # CLI binary
 ```
 


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.4.1 to 0.5.0
- Update README with i18n feature docs (`--locale` option, usage examples, project structure)
- Update version references in JSON output example and GitHub Action example

## Changes since v0.4.0
- #22: Add explicit permissions to GitHub Actions workflows
- #23: Fix config dialect setting not being applied by CLI
- #24: Add i18n support with English and Japanese translations
- #25: Cross-platform binary release workflow and fast action install
- #26: Fix LT01 trailing whitespace handling and CP03 false positives on UDFs

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [ ] CI passes on PR
- [ ] After merge, tag `v0.5.0` to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)