### PR TITLE
ci: replace Blacksmith and macos-13 with GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -25,7 +25,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -36,7 +36,7 @@ jobs:
 
   fmt:
     name: Format
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
             os: ubuntu-24.04-arm
             archive: tar.gz
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-latest
             archive: tar.gz
           - target: aarch64-apple-darwin
             os: macos-latest
@@ -38,20 +38,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
           key: release-${{ matrix.target }}
 
       - name: Build
-        run: cargo build --release -p rigsql-cli
+        run: cargo build --release -p rigsql-cli --target ${{ matrix.target }}
 
       - name: Package (Unix)
         if: matrix.archive == 'tar.gz'
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           ASSET_NAME="rigsql-${TAG}-${{ matrix.target }}.tar.gz"
-          tar czf "${ASSET_NAME}" -C target/release rigsql
-          sha256sum "${ASSET_NAME}" > "${ASSET_NAME}.sha256"
+          tar czf "${ASSET_NAME}" -C target/${{ matrix.target }}/release rigsql
+          if command -v sha256sum &>/dev/null; then
+            sha256sum "${ASSET_NAME}" > "${ASSET_NAME}.sha256"
+          else
+            shasum -a 256 "${ASSET_NAME}" > "${ASSET_NAME}.sha256"
+          fi
           echo "ASSET_NAME=${ASSET_NAME}" >> "$GITHUB_ENV"
 
       - name: Package (Windows)
@@ -60,7 +66,7 @@ jobs:
         run: |
           $tag = "${{ github.ref_name }}"
           $assetName = "rigsql-${tag}-${{ matrix.target }}.zip"
-          Compress-Archive -Path "target/release/rigsql.exe" -DestinationPath $assetName
+          Compress-Archive -Path "target/${{ matrix.target }}/release/rigsql.exe" -DestinationPath $assetName
           $hash = (Get-FileHash $assetName -Algorithm SHA256).Hash.ToLower()
           "$hash  $assetName" | Out-File -Encoding utf8 "${assetName}.sha256"
           "ASSET_NAME=$assetName" | Out-File -Append $env:GITHUB_ENV
@@ -102,7 +108,7 @@ jobs:
   # ── Publish to crates.io ──
   publish:
     name: Publish to crates.io
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:


### PR DESCRIPTION
## Summary
- Replace `blacksmith-2vcpu-ubuntu-2204` with `ubuntu-latest` in CI and release workflows (free for public repos)
- Replace deprecated `macos-13` with `macos-latest` for x86_64-apple-darwin builds (cross-compile from aarch64)
- Add explicit `--target` flag and target-specific output paths for release builds
- Handle `sha256sum` unavailability on macOS (fallback to `shasum -a 256`)

## Test plan
- [ ] CI passes on this PR (validates ubuntu-latest runner works)
- [ ] After merge, tag v0.5.0 to validate release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)