### PR TITLE
ci: add actions:read permission for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: read
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- Add `actions: read` permission to release workflow
- Fixes 401 Unauthorized error when `actions/download-artifact@v4` tries to download build artifacts
- When only `contents: write` is specified at workflow level, all other permissions (including `actions`) default to `none`

## Test plan
- [ ] After merge, re-tag v0.5.0 to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)