### PR TITLE
fix: hotfix v0.5.2 - LT11 false positive with comments after set operators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rigsql-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-config"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "rigsql-core",
  "rigsql-rules",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "serde",
  "smol_str",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-dialects"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "rigsql-core",
  "rigsql-lexer",
@@ -687,14 +687,14 @@ dependencies = [
 
 [[package]]
 name = "rigsql-i18n"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "rust-i18n",
 ]
 
 [[package]]
 name = "rigsql-lexer"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "insta",
  "rigsql-core",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-output"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "miette",
  "rigsql-core",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-parser"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "insta",
  "rigsql-core",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-rules"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "insta",
  "rigsql-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"
@@ -24,14 +24,14 @@ keywords = ["sql", "linter", "sqlfluff", "tsql", "postgres"]
 
 [workspace.dependencies]
 # Internal crates
-rigsql-core = { path = "crates/rigsql-core", version = "0.5.1" }
-rigsql-lexer = { path = "crates/rigsql-lexer", version = "0.5.1" }
-rigsql-parser = { path = "crates/rigsql-parser", version = "0.5.1" }
-rigsql-dialects = { path = "crates/rigsql-dialects", version = "0.5.1" }
-rigsql-rules = { path = "crates/rigsql-rules", version = "0.5.1" }
-rigsql-config = { path = "crates/rigsql-config", version = "0.5.1" }
-rigsql-output = { path = "crates/rigsql-output", version = "0.5.1" }
-rigsql-i18n = { path = "crates/rigsql-i18n", version = "0.5.1" }
+rigsql-core = { path = "crates/rigsql-core", version = "0.5.2" }
+rigsql-lexer = { path = "crates/rigsql-lexer", version = "0.5.2" }
+rigsql-parser = { path = "crates/rigsql-parser", version = "0.5.2" }
+rigsql-dialects = { path = "crates/rigsql-dialects", version = "0.5.2" }
+rigsql-rules = { path = "crates/rigsql-rules", version = "0.5.2" }
+rigsql-config = { path = "crates/rigsql-config", version = "0.5.2" }
+rigsql-output = { path = "crates/rigsql-output", version = "0.5.2" }
+rigsql-i18n = { path = "crates/rigsql-i18n", version = "0.5.2" }
 
 # External dependencies
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Found 5 violation(s) in 1 file(s) (1 file(s) scanned).
   "version": "1.0",
   "tool": {
     "name": "rigsql",
-    "version": "0.5.1"
+    "version": "0.5.2"
   },
   "summary": {
     "files_scanned": 1,
@@ -355,7 +355,7 @@ Found 5 violation(s) in 1 file(s) (1 file(s) scanned).
 ## GitHub Action
 
 ```yaml
-- uses: yukonsky/rigsql@v0.5.1
+- uses: yukonsky/rigsql@v0.5.2
   with:
     paths: "./queries/"
     dialect: "ansi"

--- a/crates/rigsql-rules/src/layout/lt11.rs
+++ b/crates/rigsql-rules/src/layout/lt11.rs
@@ -111,7 +111,11 @@ fn check_adjacent_newline(tokens: &[TokenSegment], idx: usize, dir: Direction) -
         if tokens[j].segment_type == SegmentType::Newline {
             return true;
         }
-        if tokens[j].segment_type != SegmentType::Whitespace {
+        // Skip whitespace and comments (e.g., `UNION -- noqa: AM02\n` should be OK)
+        if tokens[j].segment_type != SegmentType::Whitespace
+            && tokens[j].segment_type != SegmentType::LineComment
+            && tokens[j].segment_type != SegmentType::BlockComment
+        {
             return false;
         }
         j = match dir {
@@ -154,6 +158,20 @@ mod tests {
     #[test]
     fn test_lt11_accepts_newlines() {
         let violations = lint_sql("SELECT 1\nUNION\nSELECT 2", RuleLT11);
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_lt11_accepts_union_with_trailing_comment() {
+        // UNION followed by a line comment and then a newline should be OK
+        let violations = lint_sql("SELECT 1\nUNION -- noqa: AM02\nSELECT 2", RuleLT11);
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_lt11_accepts_union_with_leading_comment() {
+        // Comment before UNION on a separate line
+        let violations = lint_sql("SELECT 1\n-- comment\nUNION\nSELECT 2", RuleLT11);
         assert_eq!(violations.len(), 0);
     }
 }


### PR DESCRIPTION
## Summary

- Fixed LT11 (`set_operator_newline`) false positives when a line comment immediately follows a set operator (e.g. `UNION -- noqa: AM02\n`)
- The `check_adjacent_newline` helper was only skipping `Whitespace` segments; it now also skips `LineComment` and `BlockComment` segments so it can correctly detect the newline that follows
- Added 2 new regression tests covering comment-adjacent set operators
- Bumped version from 0.5.1 to 0.5.2 in `Cargo.toml`, `Cargo.lock`, and `README.md`

## Changes

- `crates/rigsql-rules/src/layout/lt11.rs` — skip comment segments in `check_adjacent_newline`; add 2 tests
- `Cargo.toml` / `Cargo.lock` — version 0.5.2
- `README.md` — version badge / changelog updated to 0.5.2

## Test plan

- [ ] `cargo test -p rigsql-rules` passes (including the 2 new LT11 tests)
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy` produces no new warnings
- [ ] Manually verify that `UNION -- some comment` followed by a newline no longer triggers LT11