### PR TITLE
chore: bump version to v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rigsql-cli"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-config"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "rigsql-core",
  "rigsql-rules",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-core"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "serde",
  "smol_str",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-dialects"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "rigsql-core",
  "rigsql-lexer",
@@ -687,14 +687,14 @@ dependencies = [
 
 [[package]]
 name = "rigsql-i18n"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "rust-i18n",
 ]
 
 [[package]]
 name = "rigsql-lexer"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "insta",
  "rigsql-core",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-output"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "miette",
  "rigsql-core",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-parser"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "insta",
  "rigsql-core",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-rules"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "insta",
  "rigsql-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"
@@ -24,14 +24,14 @@ keywords = ["sql", "linter", "sqlfluff", "tsql", "postgres"]
 
 [workspace.dependencies]
 # Internal crates
-rigsql-core = { path = "crates/rigsql-core", version = "0.5.2" }
-rigsql-lexer = { path = "crates/rigsql-lexer", version = "0.5.2" }
-rigsql-parser = { path = "crates/rigsql-parser", version = "0.5.2" }
-rigsql-dialects = { path = "crates/rigsql-dialects", version = "0.5.2" }
-rigsql-rules = { path = "crates/rigsql-rules", version = "0.5.2" }
-rigsql-config = { path = "crates/rigsql-config", version = "0.5.2" }
-rigsql-output = { path = "crates/rigsql-output", version = "0.5.2" }
-rigsql-i18n = { path = "crates/rigsql-i18n", version = "0.5.2" }
+rigsql-core = { path = "crates/rigsql-core", version = "0.6.0" }
+rigsql-lexer = { path = "crates/rigsql-lexer", version = "0.6.0" }
+rigsql-parser = { path = "crates/rigsql-parser", version = "0.6.0" }
+rigsql-dialects = { path = "crates/rigsql-dialects", version = "0.6.0" }
+rigsql-rules = { path = "crates/rigsql-rules", version = "0.6.0" }
+rigsql-config = { path = "crates/rigsql-config", version = "0.6.0" }
+rigsql-output = { path = "crates/rigsql-output", version = "0.6.0" }
+rigsql-i18n = { path = "crates/rigsql-i18n", version = "0.6.0" }
 
 # External dependencies
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Found 5 violation(s) in 1 file(s) (1 file(s) scanned).
   "version": "1.0",
   "tool": {
     "name": "rigsql",
-    "version": "0.5.2"
+    "version": "0.6.0"
   },
   "summary": {
     "files_scanned": 1,
@@ -355,7 +355,7 @@ Found 5 violation(s) in 1 file(s) (1 file(s) scanned).
 ## GitHub Action
 
 ```yaml
-- uses: yukonsky/rigsql@v0.5.2
+- uses: yukonsky/rigsql@v0.6.0
   with:
     paths: "./queries/"
     dialect: "ansi"


### PR DESCRIPTION
## Summary

- Bump workspace and all 8 crate versions from `0.5.2` to `0.6.0`
- Update `Cargo.lock` (auto-updated)
- Update `README.md` version references in JSON output example and GitHub Action example

## What's included in v0.6.0

- feat: consistent capitalisation policy for CP01-CP05 (#42)
- fix: CP03 capitalisation_policy support (#33)
- fix: LT04 comma loss with trailing whitespace (#43)
- chore(deps): update rust crate toml to v1 (#41)
- chore(deps): update rust crate clap_complete to v4.6.0 (#35)
- chore(deps): update github artifact actions (#40)
- chore(deps): update actions/checkout action to v6 (#39)

## Test plan

- [ ] `cargo build` passes cleanly
- [ ] `cargo test` passes
- [ ] `cargo fmt --check` passes
- [ ] Version string reported by `rigsql --version` is `0.6.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)