### PR TITLE
fix(cv05): skip NULL assignments in UPDATE SET clauses

### DIFF
--- a/crates/rigsql-rules/src/convention/cv05.rs
+++ b/crates/rigsql-rules/src/convention/cv05.rs
@@ -175,7 +175,8 @@ mod tests {
 
     #[test]
     fn test_cv05_flags_multi_column_update_where() {
-        // Multi-column SET should be skipped; nested subquery comparison flagged.
+        // Both `SET` assignments must be skipped, but the WHERE comparison
+        // with NULL should still produce exactly one violation.
         let violations = lint_sql("UPDATE t SET a = NULL, b = NULL WHERE c = NULL", RuleCV05);
         assert_eq!(violations.len(), 1);
     }

--- a/crates/rigsql-rules/src/convention/cv05.rs
+++ b/crates/rigsql-rules/src/convention/cv05.rs
@@ -36,6 +36,17 @@ impl Rule for RuleCV05 {
     }
 
     fn eval(&self, ctx: &RuleContext) -> Vec<LintViolation> {
+        // Skip assignments inside SET clauses (UPDATE ... SET col = NULL,
+        // ON CONFLICT DO UPDATE SET col = NULL). The parser reuses
+        // BinaryExpression for these assignments, but `=` here is assignment,
+        // not comparison.
+        if ctx
+            .parent
+            .is_some_and(|p| p.segment_type() == SegmentType::SetClause)
+        {
+            return vec![];
+        }
+
         let children = ctx.segment.children();
 
         // Look for pattern: <expr> <comparison_op> NULL
@@ -123,7 +134,7 @@ fn is_null_literal(seg: &Segment) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::lint_sql;
+    use crate::test_utils::{lint_sql, lint_sql_with_dialect};
 
     #[test]
     fn test_cv05_flags_equals_null() {
@@ -137,5 +148,35 @@ mod tests {
     fn test_cv05_accepts_is_null() {
         let violations = lint_sql("SELECT * FROM t WHERE a IS NULL", RuleCV05);
         assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_cv05_accepts_update_set_null_assignment() {
+        // `SET col = NULL` is an assignment in UPDATE, not a comparison.
+        let violations = lint_sql("UPDATE t SET a = NULL WHERE id = 1", RuleCV05);
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_cv05_accepts_tsql_update_set_null_assignment() {
+        let sql = "UPDATE dbo.TestTable\nSET TestColumn = NULL\nWHERE ID = 1;";
+        let violations = lint_sql_with_dialect(sql, RuleCV05, "tsql");
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_cv05_flags_where_in_update() {
+        // The assignment is fine, but the WHERE comparison with NULL should
+        // still be reported.
+        let violations = lint_sql("UPDATE t SET a = 1 WHERE b = NULL", RuleCV05);
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].fixes[0].new_text, "IS NULL");
+    }
+
+    #[test]
+    fn test_cv05_flags_multi_column_update_where() {
+        // Multi-column SET should be skipped; nested subquery comparison flagged.
+        let violations = lint_sql("UPDATE t SET a = NULL, b = NULL WHERE c = NULL", RuleCV05);
+        assert_eq!(violations.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

Fixes a false positive where CV05 incorrectly flagged `UPDATE t SET col = NULL` as a NULL comparison (closes #58).

**Root cause:** `parse_set_clause` wraps each `col = expr` assignment in a `BinaryExpression` segment. CV05 visits all `BinaryExpression` nodes looking for `= NULL` patterns, making it structurally impossible to distinguish an assignment from a comparison.

**Fix:** In `crates/rigsql-rules/src/convention/cv05.rs`, the rule now skips any `BinaryExpression` whose direct parent segment is a `SetClause`. This covers:
- ANSI `UPDATE ... SET col = NULL`
- PostgreSQL `ON CONFLICT ... DO UPDATE SET col = NULL`

Both use the same `parse_set_clause` path. T-SQL `SET @var = NULL` was never affected because the T-SQL grammar does not wrap that statement in a `BinaryExpression`.

## Changes

- `crates/rigsql-rules/src/convention/cv05.rs`: add parent-segment guard to skip `SetClause` children; add 4 regression tests

## Test Plan

- [ ] `test_cv05_accepts_update_set_null_assignment` — ANSI UPDATE SET col = NULL produces no violation
- [ ] `test_cv05_accepts_tsql_update_set_null_assignment` — T-SQL UPDATE SET col = NULL (exact repro from #58) produces no violation
- [ ] `test_cv05_flags_where_in_update` — `WHERE col = NULL` inside an UPDATE is still flagged
- [ ] `test_cv05_flags_multi_column_update_where` — multi-column SET with a WHERE clause: SET columns clean, WHERE comparison flagged
- [ ] Full workspace test suite: `cargo test --workspace`
- [ ] Format check: `cargo fmt --all -- --check`
- [ ] Clippy: `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] Manual CLI: `echo "UPDATE t SET col = NULL WHERE id = 1;" | rigsql lint --stdin-filename test.sql` → no CV05 violation on the SET, violation on the WHERE