### PR TITLE
chore: bump version to v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rigsql-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-config"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "rigsql-core",
  "rigsql-rules",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde",
  "smol_str",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-dialects"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "rigsql-core",
  "rigsql-lexer",
@@ -686,14 +686,14 @@ dependencies = [
 
 [[package]]
 name = "rigsql-i18n"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "rust-i18n",
 ]
 
 [[package]]
 name = "rigsql-lexer"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "insta",
  "rigsql-core",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-output"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "miette",
  "rigsql-core",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-parser"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "insta",
  "rigsql-core",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-rules"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "insta",
  "rigsql-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"
@@ -24,14 +24,14 @@ keywords = ["sql", "linter", "sqlfluff", "tsql", "postgres"]
 
 [workspace.dependencies]
 # Internal crates
-rigsql-core = { path = "crates/rigsql-core", version = "0.7.0" }
-rigsql-lexer = { path = "crates/rigsql-lexer", version = "0.7.0" }
-rigsql-parser = { path = "crates/rigsql-parser", version = "0.7.0" }
-rigsql-dialects = { path = "crates/rigsql-dialects", version = "0.7.0" }
-rigsql-rules = { path = "crates/rigsql-rules", version = "0.7.0" }
-rigsql-config = { path = "crates/rigsql-config", version = "0.7.0" }
-rigsql-output = { path = "crates/rigsql-output", version = "0.7.0" }
-rigsql-i18n = { path = "crates/rigsql-i18n", version = "0.7.0" }
+rigsql-core = { path = "crates/rigsql-core", version = "0.7.1" }
+rigsql-lexer = { path = "crates/rigsql-lexer", version = "0.7.1" }
+rigsql-parser = { path = "crates/rigsql-parser", version = "0.7.1" }
+rigsql-dialects = { path = "crates/rigsql-dialects", version = "0.7.1" }
+rigsql-rules = { path = "crates/rigsql-rules", version = "0.7.1" }
+rigsql-config = { path = "crates/rigsql-config", version = "0.7.1" }
+rigsql-output = { path = "crates/rigsql-output", version = "0.7.1" }
+rigsql-i18n = { path = "crates/rigsql-i18n", version = "0.7.1" }
 
 # External dependencies
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Found 5 violation(s) in 1 file(s) (1 file(s) scanned).
   "version": "1.0",
   "tool": {
     "name": "rigsql",
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "summary": {
     "files_scanned": 1,
@@ -355,7 +355,7 @@ Found 5 violation(s) in 1 file(s) (1 file(s) scanned).
 ## GitHub Action
 
 ```yaml
-- uses: yukonsky/rigsql@v0.7.0
+- uses: yukonsky/rigsql@v0.7.1
   with:
     paths: "./queries/"
     dialect: "ansi"


### PR DESCRIPTION
## Summary

Bump workspace version from `0.7.0` to `0.7.1` in preparation for the v0.7.1 patch release.

Patch bump because the only user-facing code change since v0.7.0 is a bug fix (CV05 false positive); no API surface changes.

## Notable changes since v0.7.0

- **CV05** no longer flags NULL assignments inside `UPDATE ... SET col = NULL` or PostgreSQL `ON CONFLICT ... DO UPDATE SET col = NULL`. Previously these were incorrectly reported as NULL comparisons because the parser reuses `BinaryExpression` for both comparisons and `SET`-clause assignments (#59, fixes #58).
- Dep updates: `clap` 4.6.1 (#53), `clap_complete` 4.6.5 (#56), `serde_json` 1.0.150 (#57).

## Changes in this PR

- `Cargo.toml` — `workspace.package.version` and all internal `workspace.dependencies` versions `0.7.0` → `0.7.1`
- `Cargo.lock` — regenerated via `cargo build --workspace`
- `README.md` — updated JSON output example and GitHub Action usage snippet to reference `0.7.1` / `v0.7.1`

## Test Plan

- [x] `cargo build --workspace` — clean build with the new version
- [x] `cargo test --workspace` — 323 tests pass, no regressions
- [x] `cargo fmt --all -- --check` — clean
- [x] Visual: README examples reference the new version

After merge: tag `v0.7.1` on `main` to trigger the release workflow (cross-platform binaries + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)