### PR TITLE
Fix AM02 false positive in T-SQL and noqa trailing text handling

### DIFF
--- a/crates/rigsql-config/src/lib.rs
+++ b/crates/rigsql-config/src/lib.rs
@@ -321,10 +321,13 @@ fn parse_noqa_comment(line: &str) -> Option<NoqaSpec> {
     }
 
     if let Some(rest) = after.strip_prefix(':') {
+        // Keep only the rule code from each comma-separated entry, ignoring any
+        // trailing free text (e.g. `-- noqa: AM02 (explanatory note)`), so an
+        // inline rationale can live next to the directive.
         let codes: Vec<String> = rest
             .split(',')
-            .map(|s| s.trim().to_uppercase())
-            .filter(|s| !s.is_empty())
+            .filter_map(|s| s.split_whitespace().next())
+            .map(|s| s.to_uppercase())
             .collect();
         if codes.is_empty() {
             Some(NoqaSpec::All)
@@ -361,6 +364,26 @@ mod tests {
     #[test]
     fn test_parse_noqa_none() {
         assert!(parse_noqa_comment("SELECT 1").is_none());
+    }
+
+    #[test]
+    fn test_parse_noqa_specific_with_trailing_text() {
+        match parse_noqa_comment("SELECT 1 -- noqa: AM02 (some explanatory text)") {
+            Some(NoqaSpec::Rules(codes)) => {
+                assert_eq!(codes, vec!["AM02"]);
+            }
+            _ => panic!("Expected NoqaSpec::Rules"),
+        }
+    }
+
+    #[test]
+    fn test_parse_noqa_multiple_with_trailing_text() {
+        match parse_noqa_comment("SELECT 1 -- noqa: CP01, LT01 (rationale here)") {
+            Some(NoqaSpec::Rules(codes)) => {
+                assert_eq!(codes, vec!["CP01", "LT01"]);
+            }
+            _ => panic!("Expected NoqaSpec::Rules"),
+        }
     }
 
     #[test]

--- a/crates/rigsql-rules/src/ambiguous/am02.rs
+++ b/crates/rigsql-rules/src/ambiguous/am02.rs
@@ -37,6 +37,13 @@ impl Rule for RuleAM02 {
     }
 
     fn eval(&self, ctx: &RuleContext) -> Vec<LintViolation> {
+        // T-SQL (SQL Server) does not support `UNION DISTINCT` syntax — a bare
+        // UNION is already the explicit deduplicating form, so there is nothing
+        // to make explicit. Flagging it would suggest an unsatisfiable fix.
+        if ctx.dialect == "tsql" {
+            return vec![];
+        }
+
         let mut violations = Vec::new();
         find_bare_unions(ctx.root, &mut violations);
         violations
@@ -84,7 +91,7 @@ fn find_bare_unions(segment: &Segment, violations: &mut Vec<LintViolation>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::lint_sql;
+    use crate::test_utils::{lint_sql, lint_sql_with_dialect};
 
     #[test]
     fn test_am02_flags_bare_union() {
@@ -102,6 +109,15 @@ mod tests {
     #[test]
     fn test_am02_accepts_union_distinct() {
         let violations = lint_sql("SELECT a FROM t UNION DISTINCT SELECT b FROM u", RuleAM02);
+        assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_am02_ignores_bare_union_in_tsql() {
+        // T-SQL does not support `UNION DISTINCT`, so a bare UNION must not be
+        // flagged — the implied fix would be a syntax error in SQL Server.
+        let violations =
+            lint_sql_with_dialect("SELECT a FROM t UNION SELECT b FROM u", RuleAM02, "tsql");
         assert_eq!(violations.len(), 0);
     }
 }


### PR DESCRIPTION
## Summary

Closes #66

Two independent fixes to rule evaluation and noqa comment parsing:

1. **AM02 unsatisfiable in T-SQL**: Rule AM02 ("UNION must specify explicit DISTINCT or ALL") flagged a bare `UNION` even under the `tsql` dialect. SQL Server does not support `UNION DISTINCT` syntax (it's a parse error), and a bare `UNION` is already the explicit deduplicating form in T-SQL — so the rule was unsatisfiable there. `RuleAM02::eval` now returns early with no violations when `ctx.dialect == "tsql"`, matching the existing dialect-gating convention used by `cv06.rs` and `tq03.rs`.

2. **`-- noqa` did not tolerate trailing free text**: `-- noqa: AM02 (some explanatory text)` failed to suppress the violation because the whole `AM02 (some explanatory text)` string was treated as a single rule code. `parse_noqa_comment` now takes only the first whitespace-delimited token of each comma-separated entry, so an inline rationale can live next to the directive without breaking suppression.

## Changes

- `crates/rigsql-rules/src/ambiguous/am02.rs`: gate `RuleAM02::eval` on `ctx.dialect == "tsql"`; add `test_am02_ignores_bare_union_in_tsql`.
- `crates/rigsql-config/src/lib.rs`: `parse_noqa_comment` now splits each comma-separated entry on whitespace and keeps only the first token as the rule code; add `test_parse_noqa_specific_with_trailing_text` and `test_parse_noqa_multiple_with_trailing_text`.

## Test plan

- [x] Added `test_am02_ignores_bare_union_in_tsql` covering the tsql dialect skip
- [x] Added `test_parse_noqa_specific_with_trailing_text` and `test_parse_noqa_multiple_with_trailing_text` covering trailing free text after rule codes
- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` passes (228 tests, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)