### PR TITLE
chore: bump version to v0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rigsql-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-config"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "rigsql-core",
  "rigsql-rules",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "serde",
  "smol_str",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-dialects"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "rigsql-core",
  "rigsql-lexer",
@@ -686,14 +686,14 @@ dependencies = [
 
 [[package]]
 name = "rigsql-i18n"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "rust-i18n",
 ]
 
 [[package]]
 name = "rigsql-lexer"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "insta",
  "rigsql-core",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-output"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "miette",
  "rigsql-core",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-parser"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "insta",
  "rigsql-core",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "rigsql-rules"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "insta",
  "rigsql-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 rust-version = "1.89"
 license = "MIT"
@@ -24,14 +24,14 @@ keywords = ["sql", "linter", "sqlfluff", "tsql", "postgres"]
 
 [workspace.dependencies]
 # Internal crates
-rigsql-core = { path = "crates/rigsql-core", version = "0.7.1" }
-rigsql-lexer = { path = "crates/rigsql-lexer", version = "0.7.1" }
-rigsql-parser = { path = "crates/rigsql-parser", version = "0.7.1" }
-rigsql-dialects = { path = "crates/rigsql-dialects", version = "0.7.1" }
-rigsql-rules = { path = "crates/rigsql-rules", version = "0.7.1" }
-rigsql-config = { path = "crates/rigsql-config", version = "0.7.1" }
-rigsql-output = { path = "crates/rigsql-output", version = "0.7.1" }
-rigsql-i18n = { path = "crates/rigsql-i18n", version = "0.7.1" }
+rigsql-core = { path = "crates/rigsql-core", version = "0.7.2" }
+rigsql-lexer = { path = "crates/rigsql-lexer", version = "0.7.2" }
+rigsql-parser = { path = "crates/rigsql-parser", version = "0.7.2" }
+rigsql-dialects = { path = "crates/rigsql-dialects", version = "0.7.2" }
+rigsql-rules = { path = "crates/rigsql-rules", version = "0.7.2" }
+rigsql-config = { path = "crates/rigsql-config", version = "0.7.2" }
+rigsql-output = { path = "crates/rigsql-output", version = "0.7.2" }
+rigsql-i18n = { path = "crates/rigsql-i18n", version = "0.7.2" }
 
 # External dependencies
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Found 5 violation(s) in 1 file(s) (1 file(s) scanned).
   "version": "1.0",
   "tool": {
     "name": "rigsql",
-    "version": "0.7.1"
+    "version": "0.7.2"
   },
   "summary": {
     "files_scanned": 1,
@@ -355,7 +355,7 @@ Found 5 violation(s) in 1 file(s) (1 file(s) scanned).
 ## GitHub Action
 
 ```yaml
-- uses: yukonsky/rigsql@v0.7.1
+- uses: yukonsky/rigsql@v0.7.2
   with:
     paths: "./queries/"
     dialect: "ansi"


### PR DESCRIPTION
## Summary

Patch release **v0.7.2**, covering the fixes merged since v0.7.1.

### Changes since v0.7.1
- **fix(am02):** AM02 no longer flags a bare `UNION` in the `tsql` dialect. SQL Server does not support `UNION DISTINCT` syntax, so the rule was previously unsatisfiable for T-SQL. (#67)
- **fix(noqa):** `-- noqa` now tolerates trailing free text after the rule code(s), e.g. `-- noqa: AM02 (explanatory note)`. (#67)

### Version bump
- `Cargo.toml` workspace + all internal crate versions `0.7.1` → `0.7.2`
- `Cargo.lock` regenerated
- `README.md` SARIF example and GitHub Action usage updated to `v0.7.2`

After merge, push the `v0.7.2` tag to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)